### PR TITLE
Add Unity application contents path to the default Environment initialization

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -3,9 +3,9 @@
 build:
   name: Build
   agent:
-    type: Unity::VM
-    image: core-kaunas/win10-vs2017-dotnetcore:latest
-    flavor: m1.large
+    type: {{ build_agent_type }}
+    image: {{ build_agent_image }}
+    flavor: {{ build_agent_flavor }}
   variables:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
@@ -15,7 +15,15 @@ build:
     - |
       set RELEASE=0
       if "x%GIT_TAG%"!==!"x" set RELEASE=1
-      if "%RELEASE%"=="1" (pack -r -b -p -u) else (pack -r -b -u)
+      if "%RELEASE%"=="1" (build -r -p) else (build -r)
+    - |
+      set RELEASE=0
+      if "x%GIT_TAG%"!==!"x" set RELEASE=1
+      if "%RELEASE%"=="1" (test -r -p) else (test -r)
+    - |
+      set RELEASE=0
+      if "x%GIT_TAG%"!==!"x" set RELEASE=1
+      if "%RELEASE%"=="1" (pack -r -p -u) else (pack -r -u)
 
   artifacts:
     nuget:
@@ -31,6 +39,7 @@ build:
     tests:
       paths:
         - "build/tests/bin/**/*"
+        - "tests/**/TestResults/*"
     sources:
       paths:
         - "build/upm/**/*"

--- a/.yamato/publish.yml
+++ b/.yamato/publish.yml
@@ -3,13 +3,12 @@
 publish_nuget:
   name: Publish Nuget
   agent:
-    type: Unity::VM
-    image: core-kaunas/win10-vs2017-dotnetcore:latest
-    flavor: m1.large
+    type: {{ build_agent_type }}
+    image: {{ build_agent_image }}
+    flavor: {{ build_agent_flavor }}
   interpreter: powershell
   skip_checkout: true
   variables:
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
     PUBLISH_URL: https://artifactory.internal.unity3d.com/api/nuget/core-utilities
 
   commands:
@@ -24,16 +23,16 @@ publish_nuget:
 publish_npm:
   name: Publish Npm
   agent:
-    type: Unity::VM
-    image: core-kaunas/win10-vs2017-dotnetcore:latest
-    flavor: m1.large
+    type: {{ upm_agent_type }}
+    image: {{ upm_agent_image }}
+    flavor: {{ upm_agent_flavor }}
   skip_checkout: true
   variables:
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
     PUBLISH_URL: https://artifactory.internal.unity3d.com/api/npm/core-npm
+    AUTH_URL: https://artifactory.internal.unity3d.com/api/npm/auth
 
   commands:
-    - curl -u%ARTIFACTORY% %PUBLISH_URL%/auth/artifactory > %USERPROFILE%\.npmrc
+    - curl -u%ARTIFACTORY% %AUTH_URL%/auth > %USERPROFILE%\.npmrc
     - for /f "delims=" %%d in ('dir /b "upm-ci~\packages\*.tgz"') do (call npm publish "upm-ci~\packages\%%d" --quiet --registry %PUBLISH_URL%)
 
   dependencies:
@@ -43,12 +42,10 @@ publish_npm:
 publish_packman:
   name: Publish to Candidates
   agent:
-    type: Unity::VM
-    image: core-kaunas/win10-vs2017-dotnetcore:latest
-    flavor: m1.large
+    type: {{ upm_agent_type }}
+    image: {{ upm_agent_image }}
+    flavor: {{ upm_agent_flavor }}
   skip_checkout: true
-  variables:
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
   commands:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm

--- a/.yamato/test.yml
+++ b/.yamato/test.yml
@@ -1,10 +1,9 @@
 {% metadata_file .yamato_config/config.yml %}
 ---
-{% for package in packages %}
-{% for editor in editors %}
-{% for platform in platforms %}
-test_{{ package.safename }}_{{ platform.name }}_{{ editor.version }}:
-  name : Test {{ package.name }} {{ editor.version }} on {{ platform.name }}
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+test_{{ platform.name }}_{{ editor.version }}:
+  name : Test {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
@@ -13,9 +12,10 @@ test_{{ package.safename }}_{{ platform.name }}_{{ editor.version }}:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
   commands:
-    - |
-      npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
-      upm-ci package test --package-path build\upm\{{ package.name }} -u {{editor.version}}
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+{% for package in packages %}
+    - upm-ci package test --package-path build\upm\{{ package.name }} -u {{editor.version}}
+{% endfor %}
 
   dependencies:
     - .yamato/build.yml#build
@@ -26,16 +26,13 @@ test_{{ package.safename }}_{{ platform.name }}_{{ editor.version }}:
         - "upm-ci~/test-results/**/*"
 {% endfor %}
 {% endfor %}
-{% endfor %}
 
 test_trigger:
   name: Build and Test All
   dependencies:
-    {% for package in packages %}
-    {% for editor in editors %}
-    {% for platform in platforms %}
-    - .yamato/test.yml#test_{{ package.safename }}_{{platform.name}}_{{editor.version}}
-    {% endfor %}
+    {% for editor in test_editors %}
+    {% for platform in test_platforms %}
+    - .yamato/test.yml#test_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}
   triggers:

--- a/.yamato_config/config.yml
+++ b/.yamato_config/config.yml
@@ -1,8 +1,16 @@
-platforms:
+build_agent_type: Unity::VM
+build_agent_image: core-kaunas/win10-vs2017-dotnetcore:latest
+build_agent_flavor: m1.large
+
+upm_agent_type: Unity::VM
+upm_agent_image: package-ci/win10:stable
+upm_agent_flavor: b1.large
+
+test_platforms:
   - name: win
     type: Unity::VM
-    image: core-kaunas/win10-vs2017-dotnetcore:latest
-    flavor: m1.large
+    image: package-ci/win10:stable
+    flavor: b1.large
 #  - name: mac
 #    type: Unity::VM::osx
 #    image: buildfarm/mac:stable
@@ -12,7 +20,7 @@ platforms:
 #    image: yamato/ubuntu-18.04-dotnet:latest
 #    flavor: b1.small
 
-editors:
+test_editors:
   - version: 2019.2
 
 packages:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <LangVersion>7.3</LangVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <RepoRoot Condition=" '$(RepoRoot)' == '' ">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
   </PropertyGroup>
 </Project>

--- a/build.cmd
+++ b/build.cmd
@@ -1,16 +1,42 @@
 @echo off
 setlocal
 
-SET CONFIGURATION=Debug
+SET CONFIGURATION=Release
 SET PUBLIC=""
+SET BUILD=0
+set UPM=0
 
 :loop
 IF NOT "%1"=="" (
     IF "%1"=="-p" (
         SET PUBLIC=/p:PublicRelease=true
     )
+    IF "%1"=="--public" (
+        SET PUBLIC=/p:PublicRelease=true
+    )
+    IF "%1"=="-b" (
+        SET BUILD=1
+    )
+    IF "%1"=="--build" (
+        SET BUILD=1
+    )
+    IF "%1"=="-d" (
+        SET CONFIGURATION=Debug
+    )
+    IF "%1"=="--debug" (
+        SET CONFIGURATION=Debug
+    )
     IF "%1"=="-r" (
         SET CONFIGURATION=Release
+    )
+    IF "%1"=="--release" (
+        SET CONFIGURATION=Release
+    )
+    IF "%1"=="-u" (
+        SET UPM=1
+    )
+    IF "%1"=="--upm" (
+        SET UPM=1
     )
     SHIFT
     GOTO :loop

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,10 @@ if [[ -e "/c/" ]]; then
   OS="Windows"
 fi
 
-CONFIGURATION=""
+CONFIGURATION=Release
 PUBLIC=""
+BUILD=0
+UPM=0
 
 while (( "$#" )); do
   case "$1" in
@@ -25,30 +27,27 @@ while (( "$#" )); do
       PUBLIC="/p:PublicRelease=true"
       shift
     ;;
+    -b|--build)
+      BUILD=1
+      shift
+    ;;
+    -u|--upm)
+      UPM=1
+      shift
+    ;;
     -*|--*=) # unsupported flags
       echo "Error: Unsupported flag $1" >&2
       exit 1
       ;;
-    *) # preserve positional arguments
-      if [[ x"$CONFIGURATION" != x"" ]]; then
-        echo "Invalid argument $1"
-        exit -1
-      fi
-      CONFIGURATION="$1"
-      shift
-      ;;
   esac
 done
-
-if [[ x"$CONFIGURATION" == x"" ]]; then
-  CONFIGURATION="Debug"
-fi
 
 if [[ x"$OS" == x"Windows" && x"$PUBLIC" != x"" ]]; then
   PUBLIC="/$PUBLIC"
 fi
 
 pushd $DIR >/dev/null 2>&1
+dotnet build-server shutdown >/dev/null 2>&1 || true
 dotnet restore
 dotnet build --no-restore -c $CONFIGURATION $PUBLIC
 popd >/dev/null 2>&1

--- a/common/packageversionfiles.targets
+++ b/common/packageversionfiles.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Prevent this from being imported multiple times -->
+  <Import Condition="'$(PropsIncluded)' == ''" Project="packaging.props" />
+
+  <ItemGroup>
+    <VersionFiles Include="$(IntermediateOutputPath)\$(AssemblyName).Version$(DefaultLanguageSourceExtension)" />
+  </ItemGroup>
+
+  <Target Name="CopyVersionFilesToPackage"
+    AfterTargets="AfterBuild"
+    Inputs="@(VersionFiles)"
+    Outputs="@(VersionFiles->'$(PublishTo)$(PackageName)$(PackageSubFolder)Version%(Extension)')"
+  >
+    <MakeDir Directories="$(PublishTo)$(PackageName)$(PackageSubFolder)" />
+    <Copy SkipUnchangedFiles="true" 
+      SourceFiles="@(VersionFiles)"
+      DestinationFiles="@(VersionFiles->'$(PublishTo)$(PackageName)$(PackageSubFolder)Version%(Extension)')"
+    />
+  </Target>
+
+</Project>

--- a/common/packaging.props
+++ b/common/packaging.props
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <PropsIncluded>true</PropsIncluded>
     <PublishTo Condition="'$(PublishTo)' == '' ">$(RepoRoot)build\packages\</PublishTo>
-    <CurrentFullPath>$(MSBuildProjectDirectory)</CurrentFullPath>
-    <PackageSourceRoot Condition="'$(PackageSourceRoot)' == ''">$(MSBuildProjectDirectory)\..\</PackageSourceRoot>
+    <PackageSourceRoot Condition="'$(PackageSourceRoot)' == ''">$(MSBuildProjectDirectory)\..\..\</PackageSourceRoot>
     <PackageSourceRootFull>$([System.IO.Path]::GetFullPath($(PackageSourceRoot)))</PackageSourceRootFull>
 
     <TmpPackageName>$([System.IO.Path]::GetDirectoryName($(PackageSourceRootFull)))</TmpPackageName>
     <PackageName Condition="'$(PackageName)' == '' ">$([System.IO.Path]::GetFileName($(TmpPackageName)))</PackageName>
-
-    <PackageSubFolder>\$(CurrentFullPath.Substring($(PackageSourceRootFull.Length)))\</PackageSubFolder>
     <PackageTestName>$(PackageName).tests</PackageTestName>
+
+    <CurrentFullPath>$(MSBuildProjectDirectory)</CurrentFullPath>
+    <PackageSubFolder>\$(CurrentFullPath.Substring($(PackageSourceRootFull.Length)))\</PackageSubFolder>
 
     <NpmVersionSuffix>-preview</NpmVersionSuffix>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="$(RepoRoot)icon.png" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="icon.png" />
-  </ItemGroup>
-
 </Project>

--- a/common/packaging.targets
+++ b/common/packaging.targets
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="packaging.props" />
+  <!-- Prevent this from being imported multiple times -->
+  <Import Condition="'$(PropsIncluded)' == ''" Project="packaging.props" />
+  <Import Project="packageversionfiles.targets" />
 
   <ItemGroup>
     <PackageReference Include="SpoiledCat.MSBuild.Tasks.FileUpdate" Version="1.0.13" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
-  <ItemGroup>
-    <VersionFiles Include="$(IntermediateOutputPath)\$(AssemblyName).Version$(DefaultLanguageSourceExtension)" />
-  </ItemGroup>
-
   <!-- Assemble all sources into a folder called (PackageName) -->
   <Target Name="EnumeratePackageFiles" Returns="@(SourcesToCopy)">
     <CreateItem
-      Include="$(PackageSourceRootFull)**\*.*;$(SolutionDir)\extras\$(PackageName)\**\*.*"
-      Exclude="$(PackageSourceRootFull)**\*.csproj*;$(PackageSourceRootFull)**\*.ncrunch*;$(PackageSourceRootFull)**\obj\**;$(PackageSourceRootFull)version.json*;$(PackageSourceRootFull)Tests\**;$(SolutionDir)\extras\$(PackageName)\Tests\**">
+      Include="$(PackageSourceRootFull)**\*.*;$(RootDir)\extras\$(PackageName)\**\*.*"
+      Exclude="$(PackageSourceRootFull)**\*.csproj*;$(PackageSourceRootFull)**\*.ncrunch*;$(PackageSourceRootFull)**\obj\**;$(PackageSourceRootFull)version.json*;$(PackageSourceRootFull)Tests\**;$(RootDir)\extras\$(PackageName)\Tests\**">
       <Output TaskParameter="Include" ItemName="SourcesToCopy" />
     </CreateItem>
   </Target>
@@ -23,8 +21,8 @@
   <Target Name="CopySourcesToPackmanPackage"
     DependsOnTargets="EnumeratePackageFiles"
     AfterTargets="AfterBuild"
-    Inputs="@(SourcesToCopy);@(VersionFiles)"
-    Outputs="@(SourcesToCopy->'$(PublishTo)$(PackageName)\%(RecursiveDir)%(Filename)%(Extension)');@(VersionFiles->'$(PublishTo)$(PackageName)$(PackageSubFolder)Version%(Extension)')"
+    Inputs="@(SourcesToCopy)"
+    Outputs="@(SourcesToCopy->'$(PublishTo)$(PackageName)\%(RecursiveDir)%(Filename)%(Extension)')"
     Returns="$Ran"
     >
 
@@ -36,19 +34,15 @@
       DestinationFiles="@(SourcesToCopy->'$(PublishTo)$(PackageName)\%(RecursiveDir)%(Filename)%(Extension)')"
       SkipUnchangedFiles="true" />
 
-    <Copy
-      SourceFiles="@(VersionFiles)"
-      DestinationFiles="@(VersionFiles->'$(PublishTo)$(PackageName)$(PackageSubFolder)Version%(Extension)')"
-      SkipUnchangedFiles="true" />
-
   </Target>
 
   <Target Name="UpdatePackageJson" DependsOnTargets="CopySourcesToPackmanPackage" AfterTargets="CopySourcesToPackmanPackage"
      Condition=" '$(TargetFramework)' == 'net471' " >
 
     <PropertyGroup>
-      <NpmVersion Condition="'$(PublicRelease)' != 'true'">$(BuildVersionSimple)$(NpmVersionSuffix)-g$(GitCommitIdShort)</NpmVersion>
-      <NpmVersion Condition="'$(PublicRelease)' == 'true'">$(NuGetPackageVersion)$(NpmVersionSuffix)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' == '' ">$(NuGetPackageVersion)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' != '' and '$(PublicRelease)' != 'true'">$(BuildVersionSimple)$(NpmVersionSuffix)-g$(GitCommitIdShort)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' != '' and '$(PublicRelease)' == 'true'">$(NuGetPackageVersion)$(NpmVersionSuffix)</NpmVersion>
     </PropertyGroup>
 
     <FileUpdate
@@ -82,7 +76,7 @@
       Condition="Exists('$(PublishTo)$(PackageName)\CHANGELOG.md')"
       Files="$(PublishTo)$(PackageName)\CHANGELOG.md"
       Regex="## \[VERSION\] - DATE"
-      ReplacementText="## [$(NuGetPackageVersion)] - $([System.DateTime]::Now.ToString(&quot;yyyy-MM-dd&quot;))"
+      ReplacementText="## [$(NpmVersion)] - $([System.DateTime]::Now.ToString(&quot;yyyy-MM-dd&quot;))"
       Encoding="utf-8-without-bom" />
 
     <Message Condition="'$(FileWasStamped)' == 'true'"
@@ -108,7 +102,7 @@
   <!-- Assemble all test files in a Tests folder into a package called (PackageName).tests -->
   <Target Name="EnumeratePackageTestFiles" Returns="@(TestsToCopy)">
     <CreateItem
-      Include="$(PackageSourceRootFull)\Tests\**\*.*;$(SolutionDir)\extras\$(PackageName)\Tests\**\*.*"
+      Include="$(PackageSourceRootFull)\Tests\**\*.*;$(RootDir)\extras\$(PackageName)\Tests\**\*.*"
       Exclude="$(PackageSourceRootFull)\Tests\**\*.csproj*;$(PackageSourceRootFull)\Tests\**\*.ncrunch*;$(PackageSourceRootFull)\Tests\**\obj\**;$(PackageSourceRootFull)\Tests\Helpers~\$(AssemblyName)*;$(PackageSourceRootFull)\Tests\Helpers~\nunit*;$(PackageSourceRootFull)\Tests\Helpers~\*Test*;$(PackageSourceRootFull)\Tests\Helpers~\Castle*;$(PackageSourceRootFull)\Tests\Helpers~\Microsoft*;$(PackageSourceRootFull)\Tests\Helpers~\System.*;$(PackageSourceRootFull)\Tests\Helpers~\NSubstitute*
       ">
       <Output TaskParameter="Include" ItemName="TestsToCopy" />
@@ -145,8 +139,9 @@
     Condition="Exists('$(PackageSourceRoot)\Tests') and '$(TargetFramework)' == 'net471' " >
 
     <PropertyGroup>
-    <NpmVersion Condition="'$(PublicRelease)' != 'true'">$(BuildVersionSimple)$(NpmVersionSuffix)-g$(GitCommitIdShort)</NpmVersion>
-    <NpmVersion Condition="'$(PublicRelease)' == 'true'">$(NuGetPackageVersion)$(NpmVersionSuffix)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' == '' ">$(NuGetPackageVersion)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' != '' and '$(PublicRelease)' != 'true'">$(BuildVersionSimple)$(NpmVersionSuffix)-g$(GitCommitIdShort)</NpmVersion>
+      <NpmVersion Condition=" '$(NpmVersionSuffix)' != '' and '$(PublicRelease)' == 'true'">$(NuGetPackageVersion)$(NpmVersionSuffix)</NpmVersion>
     </PropertyGroup>
 
     <FileUpdate

--- a/common/unityreferences.targets
+++ b/common/unityreferences.targets
@@ -18,8 +18,8 @@
     <HubInstallDir Condition="'$(HubInstallDir)' == '' and '$(WhatOS)' == 'win'">C:\Program Files\Unity\Hub\Editor</HubInstallDir>
     <HubInstallDir Condition="'$(HubInstallDir)' == '' and '$(WhatOS)' == 'mac'">\Applications\Unity\Hub\Editor</HubInstallDir>
     <HubInstallDir Condition="!Exists('$(HubInstallDir)')"></HubInstallDir>
-    <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\script\lib\Managed\UnityEditor.dll')">$(SolutionDir)script\lib\</UnityDir>
-    <UnityDir Condition="$(UnityDir) == '' and Exists('$(SolutionDir)\lib\Managed\UnityEditor.dll')">$(SolutionDir)lib\</UnityDir>
+    <UnityDir Condition="$(UnityDir) == '' and Exists('$(RootDir)\script\lib\Managed\UnityEditor.dll')">$(RootDir)script\lib\</UnityDir>
+    <UnityDir Condition="$(UnityDir) == '' and Exists('$(RootDir)\lib\Managed\UnityEditor.dll')">$(RootDir)lib\</UnityDir>
     <UnityDir Condition="$(UnityDir) == '' and Exists('\Applications\Unity\Unity.app\Contents\Managed\UnityEditor.dll')">\Applications\Unity\Unity.app\Contents\</UnityDir>
     <UnityDir Condition="$(UnityDir) == '' and Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEditor.dll')">C:\Program Files\Unity\Editor\Data\</UnityDir>
     <UnityDir Condition="$(UnityDir) == '' and Exists('C:\Program Files (x86)\Unity\Editor\Data\Managed\UnityEditor.dll')">C:\Program Files (x86)\Unity\Editor\Data\</UnityDir>
@@ -117,7 +117,7 @@
           3. UnityEditor.TestRunner.dll to the {0}lib\UnityExtensions/Unity/TestRunner/Editor folder
       </UnityDLLsMissingErrorText>
     </PropertyGroup>
-    <Error Condition="'$(UnityDir)' == ''" Text="$([System.String]::Format('$(UnityDLLsMissingErrorText)', '$(SolutionDir)'))" />
+    <Error Condition="'$(UnityDir)' == ''" Text="$([System.String]::Format('$(UnityDLLsMissingErrorText)', '$(RootDir)'))" />
   </Target>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,6 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Custom Packages" value="lib" />
-    <add key="Unity" value="https://artifactory.internal.unity3d.com/api/nuget/core-utilities" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/pack.cmd
+++ b/pack.cmd
@@ -1,20 +1,42 @@
 @echo off
 setlocal
 
-SET CONFIGURATION=Debug
+SET CONFIGURATION=Release
 SET PUBLIC=""
 SET BUILD=0
+set UPM=0
 
 :loop
 IF NOT "%1"=="" (
     IF "%1"=="-p" (
         SET PUBLIC=/p:PublicRelease=true
     )
+    IF "%1"=="--public" (
+        SET PUBLIC=/p:PublicRelease=true
+    )
     IF "%1"=="-b" (
         SET BUILD=1
     )
+    IF "%1"=="--build" (
+        SET BUILD=1
+    )
+    IF "%1"=="-d" (
+        SET CONFIGURATION=Debug
+    )
+    IF "%1"=="--debug" (
+        SET CONFIGURATION=Debug
+    )
     IF "%1"=="-r" (
         SET CONFIGURATION=Release
+    )
+    IF "%1"=="--release" (
+        SET CONFIGURATION=Release
+    )
+    IF "%1"=="-u" (
+        SET UPM=1
+    )
+    IF "%1"=="--upm" (
+        SET UPM=1
     )
     SHIFT
     GOTO :loop
@@ -26,3 +48,7 @@ if "x%BUILD%"=="x1" (
 )
 
 dotnet pack --no-restore --no-build -c %CONFIGURATION% %PUBLIC%
+
+if "x%UPM%"=="x1" (
+  call powershell scripts/Pack-Upm.ps1
+)

--- a/pack.sh
+++ b/pack.sh
@@ -8,7 +8,7 @@ if [[ -e "/c/" ]]; then
   OS="Windows"
 fi
 
-CONFIGURATION=""
+CONFIGURATION=Release
 PUBLIC=""
 BUILD=0
 UPM=0
@@ -39,20 +39,8 @@ while (( "$#" )); do
       echo "Error: Unsupported flag $1" >&2
       exit 1
       ;;
-    *) # preserve positional arguments
-      if [[ x"$CONFIGURATION" != x"" ]]; then
-        echo "Invalid argument $1"
-        exit -1
-      fi
-      CONFIGURATION="$1"
-      shift
-      ;;
   esac
 done
-
-if [[ x"$CONFIGURATION" == x"" ]]; then
-  CONFIGURATION="Debug"
-fi
 
 if [[ x"$OS" == x"Windows" && x"$PUBLIC" != x"" ]]; then
   PUBLIC="/$PUBLIC"

--- a/scripts/Publish-Artifactory.ps1
+++ b/scripts/Publish-Artifactory.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+Param(
+    [switch]
+    $Trace = $false
+)
+
+Set-StrictMode -Version Latest
+if ($Trace) {
+    Set-PSDebug -Trace 1
+}
+
+. $PSScriptRoot\helpers.ps1 | out-null
+
+$packagesDir = Join-Path $rootDirectory 'build\nuget\Release'
+$publishUrl = "https://artifactory.internal.unity3d.com/api/nuget/core-utilities"
+
+try {
+    Push-Location $packagesDir
+
+    Get-ChildItem -File *.nupkg | %{ 
+        Write-Output "Publishing $($_.Name) to $($publishUrl)"
+        Invoke-Command -Fatal { & dotnet nuget push $_.Name -k $($env:ARTIFACTORY) -s $publishUrl }
+    }
+
+} finally {
+    Pop-Location
+}
+
+$packagesDir = Join-Path $rootDirectory 'upm-ci~\packages'
+$publishUrl = "https://artifactory.internal.unity3d.com/api/npm/core-npm"
+$authUrl = "https://artifactory.internal.unity3d.com/api/npm/auth"
+
+$npmrc="$($env:USERPROFILE)\.npmrc"
+$npmrcBackup="$($env:USERPROFILE)\.npmrc-backup"
+$DoNpmRcBackup = Test-Path $npmrc
+
+try {
+    Push-Location $packagesDir
+
+    if ($DoNpmRcBackup) {
+        Write-Output "Backing up $npmrc to $npmrcBackup"
+        Move-Item $npmrc $npmrcBackup -Force -ErrorAction SilentlyContinue
+    }
+
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($env:ARTIFACTORY)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $basicAuthValue = "Basic $base64"
+    $headers = @{ Authorization = $basicAuthValue }
+
+    Invoke-WebRequest -usebasicparsing -Headers $headers -Uri $authUrl -OutFile $npmrc
+
+    Get-ChildItem -File *.tgz | %{ 
+        Write-Output "Publishing $($_.Name) to $($publishUrl)"
+        Invoke-Command -Fatal { & npm publish $($_.Name) --quiet --registry $publishUrl }
+    }
+
+} finally {
+    Pop-Location
+    if ($DoNpmRcBackup) {
+        Write-Output "Restoring $npmrc"
+        Move-Item $npmrcBackup $npmrc -Force -ErrorAction SilentlyContinue
+    } else {
+        Remove-Item $npmrc
+    }
+}
+

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <LangVersion>7.3</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</RepoRoot>
     <RepoBuildPath>$(RepoRoot)build\</RepoBuildPath>
@@ -10,8 +9,6 @@
     <RepoObjPath>$(RepoBuildPath)obj\</RepoObjPath>
     <BaseIntermediateOutputPath>$(RepoObjPath)$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoBinPath)$(MSBuildProjectName)\</BaseOutputPath>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-
     <PackageOutputPath>$(RepoBuildPath)nuget\$(Configuration)\</PackageOutputPath>
 
     <Authors>Unity Technologies, Andreia Gaita</Authors>
@@ -33,8 +30,6 @@ Copyright (c) 2016-2018 GitHub</Copyright>
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.38-beta-g5d1f8441c5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net471" Version="1.0.0-preview.2" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" Condition=" '$(TargetFramework)' == 'net471' " />
   </ItemGroup>
 

--- a/src/com.unity.editor.tasks/CHANGELOG.md
+++ b/src/com.unity.editor.tasks/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
 ## [VERSION] - DATE
+
+- Add Unity application contents path to the default Environment initialization
+
+## [1.1.4] - 2019-11-20
+
+- Fix native async/await support

--- a/src/com.unity.editor.tasks/Editor/Environment/TheEnvironment.cs
+++ b/src/com.unity.editor.tasks/Editor/Environment/TheEnvironment.cs
@@ -5,9 +5,7 @@
 
 using System;
 using UnityEngine;
-#if UNITY_EDITOR
 using UnityEditor;
-#endif
 
 namespace Unity.Editor.Tasks
 {
@@ -16,18 +14,14 @@ namespace Unity.Editor.Tasks
 		[NonSerialized] private IEnvironment environment;
 		[SerializeField] private string unityApplication;
 		[SerializeField] private string unityApplicationContents;
-		[SerializeField] private string unityAssetsPath;
 		[SerializeField] private string unityVersion;
 		[SerializeField] private string projectPath;
 
 		public void Flush()
 		{
-#if UNITY_EDITOR
 			unityApplication = Environment.UnityApplication;
 			unityApplicationContents = Environment.UnityApplicationContents;
 			unityVersion = Environment.UnityVersion;
-#endif
-			unityAssetsPath = Environment.UnityAssetsPath;
 			Save(true);
 		}
 
@@ -40,16 +34,15 @@ namespace Unity.Editor.Tasks
 				if (environment == null)
 				{
 					environment = new UnityEnvironment(ApplicationName ?? Application.productName);
-					if (unityAssetsPath == null)
+					if (projectPath == null)
 					{
 						projectPath = System.IO.Path.GetFullPath(".");
+						unityVersion = Application.unityVersion;
 						unityApplication = EditorApplication.applicationPath;
 						unityApplicationContents = EditorApplication.applicationContentsPath;
-						unityVersion = Application.unityVersion;
-						unityAssetsPath = Application.dataPath;
 					}
 
-					environment.Initialize(projectPath, unityAssetsPath, unityVersion, unityApplication);
+					environment.Initialize(projectPath, unityVersion, unityApplication, unityApplicationContents);
 					Flush();
 				}
 				return environment;

--- a/src/com.unity.editor.tasks/Editor/Environment/UnityEnvironment.cs
+++ b/src/com.unity.editor.tasks/Editor/Environment/UnityEnvironment.cs
@@ -8,7 +8,6 @@ namespace Unity.Editor.Tasks
 	public interface IEnvironment
 	{
 		IEnvironment Initialize(string projectPath,
-			string Application_dataPath,
 			string unityVersion = null,
 			string EditorApplication_applicationPath = default,
 			string EditorApplication_applicationContentsPath = default);
@@ -26,7 +25,6 @@ namespace Unity.Editor.Tasks
 		string UnityVersion { get; }
 		string UnityApplication { get; }
 		string UnityApplicationContents { get; }
-		string UnityAssetsPath { get; }
 		string UnityProjectPath { get; }
 		string ApplicationName { get; }
 	}
@@ -40,14 +38,12 @@ namespace Unity.Editor.Tasks
 
 		public virtual IEnvironment Initialize(
 			string projectPath,
-			string Application_dataPath,
 			string unityVersion = null,
 			string EditorApplication_applicationPath = default,
 			string EditorApplication_applicationContentsPath = default
 		)
 		{
 			UnityProjectPath = projectPath;
-			UnityAssetsPath = Application_dataPath;
 			UnityVersion = unityVersion;
 			UnityApplication = EditorApplication_applicationPath;
 			UnityApplicationContents = EditorApplication_applicationContentsPath;
@@ -83,7 +79,6 @@ namespace Unity.Editor.Tasks
 		public string UnityVersion { get; set; }
 		public string UnityApplication { get; set; }
 		public string UnityApplicationContents { get; set; }
-		public string UnityAssetsPath { get; set; }
 		public string UnityProjectPath { get; set; }
 		public string WorkingDirectory { get; private set; }
 

--- a/src/com.unity.editor.tasks/Editor/Processes/ProcessTask.cs
+++ b/src/com.unity.editor.tasks/Editor/Processes/ProcessTask.cs
@@ -568,7 +568,7 @@ namespace Unity.Editor.Tasks
 
 		IProcessTask IProcessTask.Start()
 		{
-			base.Start();
+			Start();
 			return this;
 		}
 

--- a/src/com.unity.editor.tasks/Editor/Unity.Editor.Tasks.csproj
+++ b/src/com.unity.editor.tasks/Editor/Unity.Editor.Tasks.csproj
@@ -1,9 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>net471;netcoreapp2.2</TargetFrameworks>
-    <SolutionDir Condition=" '$(SolutionDir)' == '' ">..\..\..\</SolutionDir>
+    <RootDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\'))</RootDir>
+    <PackageSourceRoot>$(MSBuildProjectDirectory)\..\</PackageSourceRoot>
+    <FullBuild Condition="'$(SolutionName)' == 'Unity.Editor.Tasks'">true</FullBuild>
+    <IsPackable Condition="'$(FullBuild)' != 'true'">false</IsPackable>
     <Description>A friendly threaded task system for the Unity Editor.</Description>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)common\unityreferences.targets" />
-  <Import Project="$(SolutionDir)common\packaging.targets" />
+
+  <ItemGroup>
+    <None Remove="lib\**;**\*.meta;*.DotSettings;*.ncrunch*;**\*.asmdef;bin\**;obj\**;LICENSE.md;version.json;package.json" />
+    <None Include="$(RootDir)icon.png" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="icon.png" Condition="Exists('$(RootDir)icon.png')"/>
+    <None Include="$(RootDir)LICENSE.md" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="LICENSE.md" Condition="Exists('$(RootDir)LICENSE.md')"/>
+  </ItemGroup>
+
+  <Import Project="$(RootDir)common\unityreferences.targets" />
+  <Import Project="$(RootDir)common\packaging.targets" Condition="'$(FullBuild)' == 'true'" />
+
+  <ItemGroup Condition="'$(FullBuild)' == 'true'">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.38-beta-g5d1f8441c5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/test.cmd
+++ b/test.cmd
@@ -1,17 +1,53 @@
 @echo off
 setlocal
 
-SET CONFIGURATION=Debug
+SET CONFIGURATION=Release
 SET PUBLIC=""
+SET BUILD=0
+set UPM=0
 
 :loop
 IF NOT "%1"=="" (
+    IF "%1"=="-p" (
+        SET PUBLIC=/p:PublicRelease=true
+    )
+    IF "%1"=="--public" (
+        SET PUBLIC=/p:PublicRelease=true
+    )
+    IF "%1"=="-b" (
+        SET BUILD=1
+    )
+    IF "%1"=="--build" (
+        SET BUILD=1
+    )
+    IF "%1"=="-d" (
+        SET CONFIGURATION=Debug
+    )
+    IF "%1"=="--debug" (
+        SET CONFIGURATION=Debug
+    )
     IF "%1"=="-r" (
         SET CONFIGURATION=Release
+    )
+    IF "%1"=="--release" (
+        SET CONFIGURATION=Release
+    )
+    IF "%1"=="-u" (
+        SET UPM=1
+    )
+    IF "%1"=="--upm" (
+        SET UPM=1
     )
     SHIFT
     GOTO :loop
 )
 
-dotnet restore
-dotnet test --no-build --no-restore -c %CONFIGURATION%
+if "x%BUILD%"=="x1" (
+	dotnet restore
+	dotnet build --no-restore -c %CONFIGURATION% %PUBLIC%
+)
+dotnet test --no-build --no-restore -c %CONFIGURATION% %PUBLIC% --logger "trx;LogFileName=dotnet-test-result.trx" --logger "html;LogFileName=dotnet-test-result.html"
+
+if "x%UPM%"=="x1" (
+  call powershell scripts/Test-Upm.ps1
+)

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ if [[ -e "/c/" ]]; then
   OS="Windows"
 fi
 
-CONFIGURATION=""
+CONFIGURATION=Release
 PUBLIC=""
 BUILD=0
 UPM=0
@@ -39,34 +39,23 @@ while (( "$#" )); do
       echo "Error: Unsupported flag $1" >&2
       exit 1
       ;;
-    *) # preserve positional arguments
-      if [[ x"$CONFIGURATION" != x"" ]]; then
-        echo "Invalid argument $1"
-        exit -1
-      fi
-      CONFIGURATION="$1"
-      shift
-      ;;
   esac
 done
-
-if [[ x"$CONFIGURATION" == x"" ]]; then
-  CONFIGURATION="Debug"
-fi
 
 if [[ x"$OS" == x"Windows" && x"$PUBLIC" != x"" ]]; then
   PUBLIC="/$PUBLIC"
 fi
 
-pushd $DIR
+pushd $DIR >/dev/null 2>&1
 if [[ x"$BUILD" == x"1" ]]; then
   dotnet restore
   dotnet build --no-restore -c $CONFIGURATION $PUBLIC
 fi
-dotnet test --no-build --no-restore -c $CONFIGURATION $PUBLIC
+
+dotnet test --no-build --no-restore -c $CONFIGURATION $PUBLIC --logger "trx;LogFileName=dotnet-test-result.trx" --logger "html;LogFileName=dotnet-test-result.html"
 
 if [[ x"$UPM" == x"1" ]]; then
   powershell scripts/Test-Upm.ps1
 fi
 
-popd
+popd >/dev/null 2>&1

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,11 +1,16 @@
 <Project>
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <LangVersion>7.3</LangVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</RepoRoot>
     <NoWarn>NU5104</NoWarn>
     <IsPackable>false</IsPackable>
+  
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</RepoRoot>
+    <RepoBuildPath>$(RepoRoot)build\tests\</RepoBuildPath>
+    <RepoBinPath>$(RepoBuildPath)bin\</RepoBinPath>
+    <RepoObjPath>$(RepoBuildPath)obj\</RepoObjPath>
+    <BaseIntermediateOutputPath>$(RepoObjPath)$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoBinPath)$(MSBuildProjectName)\</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Tasks.Tests/Tasks.Tests.csproj
+++ b/tests/Tasks.Tests/Tasks.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
+    <RootDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\'))</RootDir>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\src\com.unity.editor.tasks\Tests\**\*.cs" Exclude="..\..\src\com.unity.editor.tasks\Tests\**\UnityBaseTest.cs" />
@@ -8,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)LICENSE.md" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="LICENSE.md" />
+    <None Include="$(RootDir)LICENSE.md" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
   
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -3,6 +3,7 @@
   "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
+    "^refs/heads/v\\d+\\.\\d+",
     "^refs/tags/v\\d+\\.\\d+"
   ],
   "inherit": false


### PR DESCRIPTION
Fix initialization of the Environment object via the singleton scriptable
object, it wasn't saving the Unity application contents path (which is useful
for running tools shipped with Unity, like mono)

Some build infrastructure fixes.